### PR TITLE
Initial Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+.vagrant/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
+dist: trusty
 language: bash
+before_install:
+        - wget https://raw.githubusercontent.com/dokku/dokku/v0.4.6/bootstrap.sh && sudo DOKKU_TAG="v0.4.6" bash bootstrap.sh
 install:
         - sudo make ci-dependencies install
         - sudo initctl reload-configuration

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: required
 language: bash
-install: sudo make ci-dependencies install
-script: make test
+install:
+        - sudo make ci-dependencies install
+        - sudo initctl reload-configuration
+        - sleep 5
+script:
+        - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+sudo: required
+language: bash
+install: sudo make ci-dependencies
+script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: required
 language: bash
-install: sudo make ci-dependencies
+install: sudo make ci-dependencies install
 script: make test

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2015 Jose Diaz-Gonzalez
+Copyright (C) 2015 Jose Diaz-Gonzalez, Josh McRae
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 # Assumes Ubuntu 14.04
 
-.PHONY: install develop ci-dependencies test
+.PHONY: install develop ci-dependencies socat test
 
 install:
 	cp bin/dokku-daemon /usr/local/bin/dokku-daemon
 	cp init/dokku-daemon.conf /etc/init/dokku-daemon.conf
-	sleep 5 && initctl reload-configuration
+	$(MAKE) socat
 
 develop:
 	ln -s $(PWD)/bin/dokku-daemon /usr/local/bin/dokku-daemon
 	ln -s $(PWD)/init/dokku-daemon.conf /etc/init/dokku-daemon.conf
-	sleep 5 && initctl reload-configuration
+	$(MAKE) socat
 
 ci-dependencies: shellcheck bats
 
@@ -33,6 +33,16 @@ ifeq ($(shell uname),Darwin)
 else
 	sudo add-apt-repository ppa:duggan/bats --yes
 	sudo apt-get update -qq && sudo apt-get install -qq -y bats
+endif
+endif
+
+socat:
+ifeq ($(shell socat > /dev/null 2>&1 ; echo $$?),127)
+ifeq ($(shell uname),Darwin)
+	brew install socat
+else
+	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
+	sudo apt-get update -qq && sudo apt-get install -qq -y socat
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Assumes Ubuntu 14.04
+
+.PHONY: install install-development test test-deps
+
+install:
+	cp bin/dokku-daemon /usr/local/bin/dokku-daemon
+	cp init/dokku-daemon.conf /etc/init/dokku-daemon.conf
+
+install-development:
+	ln -s $(PWD)/bin/dokku-daemon /usr/local/bin/dokku-daemon
+	ln -s $(PWD)/init/dokku-daemon.conf /etc/init/dokku-daemon.conf
+	sleep 5 && initctl reload-configuration
+
+test:
+	@bats tests || true
+
+test-deps:
+ifneq ($(shell bats --version > /dev/null 2>&1 ; echo $$?),0)
+	git clone https://github.com/sstephenson/bats.git /tmp/bats
+	cd /tmp/bats && sudo ./install.sh /usr/local
+	rm -rf /tmp/bats
+endif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,37 @@
 # dokku-daemon
 
-A daemon wrapper around dokku
+A daemon wrapper around [Dokku](https://github.com/dokku/dokku)
 
-WIP
+## Requirements
+A VM running Ubuntu 14.04 x64 with Dokku v0.4.6 installed
+
+## Installing
+Clone this repository, and as a user with access to `sudo`:
+
+    cd /path/to/dokku-daemon
+    sudo make install
+
+## Protocol
+The daemon listens on a UNIX domain socket (by default created at `/tmp/dokku-daemon.sock`) and responds to commands with line-delimited JSON. Clients are served in order of connection.
+
+    < apps:create demo-app
+    > {"ok":true,"output":"Creating demo-app... done"}
+
+Note that commands are identical in form to those issued to the `dokku` command-line interface.
+
+## Development
+A development environment can be started with the provided Vagrantfile. To start the box and run the test suite:
+
+    # on development machine
+    cd /path/to/dokku-daemon
+    vagrant up
+    vagrant ssh
+    
+    # over vagrant ssh session
+    cd /dokku-daemon
+    make test
+
+The executable and Upstart init are symlinked to their respective directories rather than copied.
+
+## License
+MIT License - See `LICENSE.txt`

--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ Clone this repository, and as a user with access to `sudo`:
     cd /path/to/dokku-daemon
     sudo make install
 
-## Protocol
-The daemon listens on a UNIX domain socket (by default created at `/tmp/dokku-daemon.sock`) and responds to commands with line-delimited JSON. Clients are served in order of connection.
+## Specifications
+* Daemon listens on a UNIX domain socket (by default created at `/tmp/dokku-daemon.sock`)
+* Commands issued to the daemon take the same form as those used with `dokku` on the cli
+* Command names are validated before execution
+* Responses are sent as line-delimited JSON
+* No authentication layer (local/container connections only)
+* Multiple client connections are supported but only one command will be processed at a given time
 
+Example command and response:
     < apps:create demo-app
     > {"ok":true,"output":"Creating demo-app... done"}
-
-Note that commands are identical in form to those issued to the `dokku` command-line interface.
 
 ## Development
 A development environment can be started with the provided Vagrantfile. To start the box and run the test suite:
@@ -34,4 +38,4 @@ A development environment can be started with the provided Vagrantfile. To start
 The executable and Upstart init are symlinked to their respective directories rather than copied.
 
 ## License
-(MIT License)[LICENSE.txt]
+[MIT License](LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ A development environment can be started with the provided Vagrantfile. To start
 The executable and Upstart init are symlinked to their respective directories rather than copied.
 
 ## License
-MIT License - See `LICENSE.txt`
+(MIT License)[LICENSE.txt]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+BOX_NAME = ENV["BOX_NAME"] || "bento/ubuntu-14.04"
+BOX_MEMORY = ENV["BOX_MEMORY"] || "512"
+DOKKU_TAG = "v0.4.6"
+DOKKU_DOMAIN = ENV["DOKKU_DOMAIN"] || "dokku.me"
+DOKKU_IP = ENV["DOKKU_IP"] || "10.0.0.2"
+
+Vagrant.configure(2) do |config|
+  config.vm.box = BOX_NAME
+  config.ssh.forward_agent = true
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    # Ubuntu's Raring 64-bit cloud image is set to a 32-bit Ubuntu OS type by
+    # default in Virtualbox and thus will not boot. Manually override that.
+    vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
+    vb.customize ["modifyvm", :id, "--memory", BOX_MEMORY]
+  end
+
+  config.vm.define "dokku-daemon", primary: true do |vm|
+    vm.vm.synced_folder File.dirname(__FILE__), "/dokku-daemon"
+
+    vm.vm.network :forwarded_port, guest: 80, host: 8080
+    vm.vm.network :private_network, ip: DOKKU_IP
+    vm.vm.hostname = "#{DOKKU_DOMAIN}"
+
+    vm.vm.provision :shell, :inline => "apt-get update > /dev/null && apt-get -qq -y install git > /dev/null"
+    vm.vm.provision :shell, :inline => "wget https://raw.githubusercontent.com/dokku/dokku/#{DOKKU_TAG}/bootstrap.sh && DOKKU_TAG=#{DOKKU_TAG} bash bootstrap.sh"
+    vm.vm.provision :shell, :inline => "cd /dokku-daemon && make test-deps install-development"
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,6 @@ Vagrant.configure(2) do |config|
 
     vm.vm.provision :shell, :inline => "apt-get update > /dev/null && apt-get -qq -y install git > /dev/null"
     vm.vm.provision :shell, :inline => "wget https://raw.githubusercontent.com/dokku/dokku/#{DOKKU_TAG}/bootstrap.sh && DOKKU_TAG=#{DOKKU_TAG} bash bootstrap.sh"
-    vm.vm.provision :shell, :inline => "cd /dokku-daemon && make test-deps install-development"
+    vm.vm.provision :shell, :inline => "cd /dokku-daemon && make ci-dependencies develop"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,5 +29,6 @@ Vagrant.configure(2) do |config|
     vm.vm.provision :shell, :inline => "apt-get update > /dev/null && apt-get -qq -y install git > /dev/null"
     vm.vm.provision :shell, :inline => "wget https://raw.githubusercontent.com/dokku/dokku/#{DOKKU_TAG}/bootstrap.sh && DOKKU_TAG=#{DOKKU_TAG} bash bootstrap.sh"
     vm.vm.provision :shell, :inline => "cd /dokku-daemon && make ci-dependencies develop"
+    vm.vm.provision :shell, :inline => "initctl reload-configuration"
   end
 end

--- a/bin/dokku-daemon
+++ b/bin/dokku-daemon
@@ -21,7 +21,11 @@ log() {
 }
 
 json_encode() {
-  [[ "$2" -eq 0 ]] && local status="true" || local status="false"
+  if [[ "$2" -eq 0 ]]; then
+    local status="true"
+  else
+    local status="false"
+  fi
 
   # Replace newlines with their escaped counterparts
   local output=$(echo -n "$1" | sed ':a;N;$!ba;s/\n/\\n/g')
@@ -97,7 +101,7 @@ server() {
 }
 
 main() {
-  while [[ "$#" > 0 ]]; do
+  while [[ "$#" -gt 0 ]]; do
     case "$1" in
       -h)
         usage

--- a/bin/dokku-daemon
+++ b/bin/dokku-daemon
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -eo pipefail
+
+VERSION="0.0.1"
+DOKKU_SOCK_PATH=${DOKKU_SOCK_PATH:="/tmp/dokku-daemon.sock"}
+DOKKU_FIFO_PATH=${DOKKU_FIFO_PATH:="/tmp/dokku-daemon.fifo"}
+DOKKU_LOGS_DIR=${DOKKU_LOGS_DIR:="/var/log/dokku"}
+
+usage() {
+  echo "Usage: dokku-daemon [-h|-v]"
+}
+
+version() {
+  echo "Version $VERSION"
+}
+
+log() {
+  timestamp=$(date "+%Y-%m-%d %H:%M:%S %Z")
+  echo "[$timestamp] $1" >> "$DOKKU_LOGS_DIR/dokku-daemon.log"
+}
+
+json_encode() {
+  [[ "$2" -eq 0 ]] && local status="true" || local status="false"
+
+  # Replace newlines with their escaped counterparts
+  local output=$(echo -n "$1" | sed ':a;N;$!ba;s/\n/\\n/g')
+
+  printf '{"ok":%s,"output":"%s"}' "$status" "$output"
+}
+
+cleanup() {
+  rm -f "$DOKKU_SOCK_PATH"
+  rm -f "$DOKKU_FIFO_PATH"
+
+  log "Stopping daemon..."
+
+  trap - TERM && kill 0
+}
+
+server() {
+  trap 'cleanup' TERM ABRT QUIT EXIT KILL
+
+  # list valid commands for dokku
+  local commands=$(dokku help | awk '/^    /{ print $1 }')
+
+  # remove previously created devices
+  rm -f "$DOKKU_SOCK_PATH"
+  rm -f "$DOKKU_FIFO_PATH"
+
+  mkfifo "$DOKKU_FIFO_PATH"
+
+  # start accepting connections
+  log "Listening on $DOKKU_SOCK_PATH..."
+
+  nc -lkU "$DOKKU_SOCK_PATH" < "$DOKKU_FIFO_PATH" | while read input; do
+    # parse command components into an array
+    local cmd=($input)
+
+    case "${cmd[0]}" in
+      shell)
+        response="Not implemented"
+        status=1
+        ;;
+      commands)
+        response="$commands"
+        status=0
+        ;;
+      *)
+        if echo "$commands" | grep -q "^${cmd[0]}$"; then
+          set +e
+
+          if [[ "${cmd[0]}" = "apps:destroy" ]]; then
+            response=$(echo "${cmd[1]}" | dokku "${cmd[@]}" 2>&1)
+          else
+            response=$(dokku "${cmd[@]}" 2>&1)
+            status="$?"
+          fi
+
+          set -e
+        else
+          response="Invalid command"
+          status=1
+        fi
+        ;;
+    esac
+
+    formatted=$(json_encode "$response" "$status")
+
+    log "[cmd] $input"
+    log "[res] $formatted"
+
+    echo "$formatted"
+  done > "$DOKKU_FIFO_PATH" &
+
+  wait
+}
+
+main() {
+  while [[ "$#" > 0 ]]; do
+    case "$1" in
+      -h)
+        usage
+        exit 0
+        ;;
+      -v)
+        version
+        exit 0
+        ;;
+      *)
+        echo "Error: Unkown option $1" 1>&2
+        exit 1
+        ;;
+    esac
+  done
+
+  server
+}
+
+main "$@"

--- a/bin/dokku-daemon
+++ b/bin/dokku-daemon
@@ -3,9 +3,9 @@
 set -eo pipefail
 
 VERSION="0.0.1"
-DOKKU_SOCK_PATH=${DOKKU_SOCK_PATH:="/tmp/dokku-daemon.sock"}
-DOKKU_FIFO_PATH=${DOKKU_FIFO_PATH:="/tmp/dokku-daemon.fifo"}
-DOKKU_LOGS_DIR=${DOKKU_LOGS_DIR:="/var/log/dokku"}
+export DOKKU_SOCK_PATH=${DOKKU_SOCK_PATH:="/tmp/dokku-daemon.sock"}
+export DOKKU_LOCK_PATH=${DOKKU_LOCK_PATH:="/tmp/dokku-daemon.lock"}
+export DOKKU_DAEMON_LOGFILE=${DOKKU_DAEMON_LOGFILE:="/var/log/dokku/dokku-daemon.log"}
 
 usage() {
   echo "Usage: dokku-daemon [-h|-v]"
@@ -17,7 +17,7 @@ version() {
 
 log() {
   timestamp=$(date "+%Y-%m-%d %H:%M:%S %Z")
-  echo "[$timestamp] $1" >> "$DOKKU_LOGS_DIR/dokku-daemon.log"
+  echo "[$timestamp] $1" >> "$DOKKU_DAEMON_LOGFILE"
 }
 
 json_encode() {
@@ -33,9 +33,13 @@ json_encode() {
   printf '{"ok":%s,"output":"%s"}' "$status" "$output"
 }
 
+cache_commands() {
+  dokku help | awk '/^    /{ print $1 }' > "$DOKKU_LOCK_PATH"
+}
+
 cleanup() {
   rm -f "$DOKKU_SOCK_PATH"
-  rm -f "$DOKKU_FIFO_PATH"
+  rm -f "$DOKKU_LOCK_PATH"
 
   log "Stopping daemon..."
 
@@ -45,19 +49,21 @@ cleanup() {
 server() {
   trap 'cleanup' TERM ABRT QUIT EXIT KILL
 
-  # list valid commands for dokku
-  local commands=$(dokku help | awk '/^    /{ print $1 }')
-
   # remove previously created devices
+  rm -f "$DOKKU_LOCK_PATH"
   rm -f "$DOKKU_SOCK_PATH"
-  rm -f "$DOKKU_FIFO_PATH"
 
-  mkfifo "$DOKKU_FIFO_PATH"
+  # valid commands are written to the lock file
+  cache_commands
 
   # start accepting connections
   log "Listening on $DOKKU_SOCK_PATH..."
 
-  nc -lkU "$DOKKU_SOCK_PATH" < "$DOKKU_FIFO_PATH" | while read input; do
+  socat unix-listen:"$DOKKU_SOCK_PATH",fork exec:"$0 -c",fdin=3,fdout=4
+}
+
+connection() {
+  while read -u 3 input; do
     # parse command components into an array
     local cmd=($input)
 
@@ -67,17 +73,23 @@ server() {
         status=1
         ;;
       commands)
-        response="$commands"
+        response=$(cat "$DOKKU_LOCK_PATH")
+        status=0
+        ;;
+      refresh)
+        cache_commands
+        response="Refreshed commands"
         status=0
         ;;
       *)
-        if echo "$commands" | grep -q "^${cmd[0]}$"; then
+        if grep -q "^${cmd[0]}$" "$DOKKU_LOCK_PATH"; then
           set +e
 
           if [[ "${cmd[0]}" = "apps:destroy" ]]; then
-            response=$(echo "${cmd[1]}" | dokku "${cmd[@]}" 2>&1)
+            response=$(echo "${cmd[1]}" | flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" 2>&1)
+            status="$?"
           else
-            response=$(dokku "${cmd[@]}" 2>&1)
+            response=$(flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" 2>&1)
             status="$?"
           fi
 
@@ -94,10 +106,8 @@ server() {
     log "[cmd] $input"
     log "[res] $formatted"
 
-    echo "$formatted"
-  done > "$DOKKU_FIFO_PATH" &
-
-  wait
+    echo "$formatted" >&4
+  done
 }
 
 main() {
@@ -109,6 +119,10 @@ main() {
         ;;
       -v)
         version
+        exit 0
+        ;;
+      -c)
+        connection
         exit 0
         ;;
       *)

--- a/init/dokku-daemon.conf
+++ b/init/dokku-daemon.conf
@@ -1,0 +1,14 @@
+# dokku-daemon
+
+description "Daemon for the remote management of Dokku"
+author "Josh McRae"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+exec /usr/local/bin/dokku-daemon
+
+post-start script
+  sleep 2
+  chmod 777 ${DOKKU_SOCK_PATH:="/tmp/dokku-daemon.sock"}
+end script

--- a/tests/functional.bats
+++ b/tests/functional.bats
@@ -29,8 +29,6 @@ load test_helper
   [ -e "$BATS_TMPDIR/dokku-custom.sock" ]
 
   daemon_stop
-
-  rm -f "$BATS_TMPDIR/dokku-custom.sock"
 }
 
 @test "(env) DOKKU_LOGS_DIR controls location of daemon's logs" {
@@ -64,7 +62,6 @@ load test_helper
 
   run create_app "destroy-me"
   run client_command "apps:destroy destroy-me"
-  echo "$output"
   assert_output_contains "Destroying destroy-me"
   run destroy_app "destroy-me"
 

--- a/tests/functional.bats
+++ b/tests/functional.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "(cli) invoking with -h displays usage" {
+  run dokku-daemon -h
+
+  assert_success
+  assert_output_contains "Usage:"
+}
+
+@test "(cli) invoking with -v displays version number" {
+  run dokku-daemon -v
+
+  assert_success
+  assert_output_contains "[0-9]\.[0-9]\.[0-9]"
+}
+
+@test "(cli) invoking with unknown option results in failure" {
+  run dokku-daemon --batman
+
+  assert_failure
+  assert_output_contains "Error:"
+}
+
+@test "(env) DOKKU_SOCK_PATH controls location of daemon's socket" {
+  daemon_start DOKKU_SOCK_PATH="$BATS_TMPDIR/dokku-custom.sock"
+
+  [ -e "$BATS_TMPDIR/dokku-custom.sock" ]
+
+  daemon_stop
+
+  rm -f "$BATS_TMPDIR/dokku-custom.sock"
+}
+
+@test "(env) DOKKU_LOGS_DIR controls location of daemon's logs" {
+  daemon_start DOKKU_LOGS_DIR="$BATS_TMPDIR"
+
+  [ -e "$BATS_TMPDIR/dokku-daemon.log" ]
+
+  daemon_stop
+}
+
+@test "(cmd) invalid dokku commands receive standard response" {
+  daemon_start
+
+  run client_command "app"
+  assert_output_contains '"ok":false'
+  assert_output_contains '"output":"Invalid command"'
+
+  run client_command "foobar"
+  assert_output_contains '"ok":false'
+  assert_output_contains '"output":"Invalid command"'
+
+  daemon_stop
+}
+
+@test "(cmd) commands that prompt the user are handled correctly" {
+  daemon_start
+
+  run client_command "shell"
+  assert_output_contains '"ok":false'
+  assert_output_contains '"output":"Not implemented"'
+
+  run create_app "destroy-me"
+  run client_command "apps:destroy destroy-me"
+  echo "$output"
+  assert_output_contains "Destroying destroy-me"
+  run destroy_app "destroy-me"
+
+  daemon_stop
+}
+
+@test "(cmd) responses are encoded as a single line" {
+  daemon_start
+
+  run create_app demo-app-one
+  run create_app demo-app-two
+
+  run client_command "apps"
+  assert_output_contains "\\n"
+  [ "${#lines[@]}" -eq 1 ]
+
+  run destroy_app demo-app-one
+  run destroy_app demo-app-two
+
+  daemon_stop
+}
+
+@test "(cmd) commands and responses are logged" {
+  daemon_start DOKKU_LOGS_DIR="$BATS_TMPDIR"
+
+  run client_command "apps:create demo-app-log"
+  response="$output"
+
+  run cat "$BATS_TMPDIR/dokku-daemon.log"
+  assert_output_contains "apps:create demo-app-log"
+  assert_output_contains "$response"
+
+  run destroy_app "demo-app-log"
+
+  daemon_stop
+}

--- a/tests/functional.bats
+++ b/tests/functional.bats
@@ -6,35 +6,35 @@ load test_helper
   run dokku-daemon -h
 
   assert_success
-  assert_output_contains "Usage:"
+  assert_contains "${lines[*]}" "Usage:"
 }
 
 @test "(cli) invoking with -v displays version number" {
   run dokku-daemon -v
 
   assert_success
-  assert_output_contains "[0-9]\.[0-9]\.[0-9]"
+  assert_contains "${lines[*]}" "Version"
 }
 
 @test "(cli) invoking with unknown option results in failure" {
   run dokku-daemon --batman
 
-  assert_failure
-  assert_output_contains "Error:"
+  assert_exit_status 1
+  assert_contains "${lines[*]}" "Error:"
 }
 
 @test "(env) DOKKU_SOCK_PATH controls location of daemon's socket" {
   daemon_start DOKKU_SOCK_PATH="$BATS_TMPDIR/dokku-custom.sock"
 
-  [ -e "$BATS_TMPDIR/dokku-custom.sock" ]
+  assert_exists "$BATS_TMPDIR/dokku-custom.sock"
 
   daemon_stop
 }
 
-@test "(env) DOKKU_LOGS_DIR controls location of daemon's logs" {
-  daemon_start DOKKU_LOGS_DIR="$BATS_TMPDIR"
+@test "(env) DOKKU_DAEMON_LOGFILE controls location of daemon's logs" {
+  daemon_start DOKKU_DAEMON_LOGFILE="$BATS_TMPDIR/dokku-daemon.log"
 
-  [ -e "$BATS_TMPDIR/dokku-daemon.log" ]
+  assert_exists "$BATS_TMPDIR/dokku-daemon.log"
 
   daemon_stop
 }
@@ -43,12 +43,12 @@ load test_helper
   daemon_start
 
   run client_command "app"
-  assert_output_contains '"ok":false'
-  assert_output_contains '"output":"Invalid command"'
+  assert_contains "${lines[*]}" '"ok":false'
+  assert_contains "${lines[*]}" '"output":"Invalid command"'
 
   run client_command "foobar"
-  assert_output_contains '"ok":false'
-  assert_output_contains '"output":"Invalid command"'
+  assert_contains "${lines[*]}" '"ok":false'
+  assert_contains "${lines[*]}" '"output":"Invalid command"'
 
   daemon_stop
 }
@@ -57,12 +57,12 @@ load test_helper
   daemon_start
 
   run client_command "shell"
-  assert_output_contains '"ok":false'
-  assert_output_contains '"output":"Not implemented"'
+  assert_contains "${lines[*]}" '"ok":false'
+  assert_contains "${lines[*]}" '"output":"Not implemented"'
 
   run create_app "destroy-me"
   run client_command "apps:destroy destroy-me"
-  assert_output_contains "Destroying destroy-me"
+  assert_contains "${lines[*]}" "Destroying destroy-me"
   run destroy_app "destroy-me"
 
   daemon_stop
@@ -75,7 +75,7 @@ load test_helper
   run create_app demo-app-two
 
   run client_command "apps"
-  assert_output_contains "\\n"
+  assert_contains "${lines[*]}" "\\n"
   [ "${#lines[@]}" -eq 1 ]
 
   run destroy_app demo-app-one
@@ -85,14 +85,14 @@ load test_helper
 }
 
 @test "(cmd) commands and responses are logged" {
-  daemon_start DOKKU_LOGS_DIR="$BATS_TMPDIR"
+  daemon_start DOKKU_DAEMON_LOGFILE="$BATS_TMPDIR/dokku-daemon.log"
 
   run client_command "apps:create demo-app-log"
   response="$output"
 
   run cat "$BATS_TMPDIR/dokku-daemon.log"
-  assert_output_contains "apps:create demo-app-log"
-  assert_output_contains "$response"
+  assert_contains "${lines[*]}" "apps:create demo-app-log"
+  assert_contains "${lines[*]}" "$response"
 
   run destroy_app "demo-app-log"
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,38 @@
+# test functions
+assert_success() {
+  [[ "$status" -eq 0 ]]
+}
+
+assert_failure() {
+  [[ "$status" -ne 0 ]]
+}
+
+assert_output() {
+  [[ "$output" = "$1" ]]
+}
+
+assert_output_contains() {
+  echo "$output" | grep "$1"
+}
+
+# dokku functions
+create_app() {
+  dokku apps:create "$1"
+}
+
+destroy_app() {
+  echo "$1" | dokku apps:destroy "$1"
+}
+
+# dokku-daemon functions
+daemon_start() {
+  sudo start dokku-daemon "$@"  &> /dev/null || sudo restart dokku-daemon "$@" &> /dev/null
+}
+
+daemon_stop() {
+  sudo stop dokku-daemon &> /dev/null
+}
+
+client_command() {
+  echo "$1" | sudo nc -U "/tmp/dokku-daemon.sock" -q 2
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,18 +1,50 @@
 # test functions
-assert_success() {
-  [[ "$status" -eq 0 ]]
+flunk() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "$*"
+    fi
+  }
+  return 1
 }
 
-assert_failure() {
-  [[ "$status" -ne 0 ]]
+assert_equal() {
+  if [ "$1" != "$2" ]; then
+    { echo "expected: $1"
+      echo "actual:   $2"
+    } | flunk
+  fi
+}
+
+assert_exit_status() {
+  assert_equal "$status" "$1"
+}
+
+assert_success() {
+  if [ "$status" -ne 0 ]; then
+    flunk "command failed with exit status $status"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_exists() {
+  if [ ! -e "$1" ]; then
+    flunk "expected file to exist: $1"
+  fi
+}
+
+assert_contains() {
+  if [[ "$1" != *"$2"* ]]; then
+    flunk "expected $2 to be in: $1"
+  fi
 }
 
 assert_output() {
-  [[ "$output" = "$1" ]]
-}
-
-assert_output_contains() {
-  echo "$output" | grep "$1"
+  local expected
+  if [ $# -eq 0 ]; then expected="$(cat -)"
+  else expected="$1"
+  fi
+  assert_equal "$expected" "$output"
 }
 
 # dokku functions


### PR DESCRIPTION
This pull request introduces a daemon satisfying the general spec in dokku/dokku#1559. In the interest of simplicity and consistency with other Dokku projects it is implemented in Bash and uses only `netcat` for communication with the socket.

Features:
- Daemon listens on a UNIX domain socket (easily mounted in a Docker container)
- Commands issued by clients match the format of those issued to the `dokku` cli
- Responses are sent as line-delimited JSON
- No authentication layer (local connections only)
- Only one client and one command can be served at a time

One slight deviation from the spec is the response format. Line-delimited JSON makes it easier for clients to consume responses as it doesn't require the use of a streaming parser. In this way both commands and responses are delimited with a newline character and more primitive clients can be built.

Validation is currently only run against command names (sourced from `dokku help`) and not their arguments. A list of valid commands is generated when the daemon starts to speed up responses however this does mean that commands for newly installed plugins will be invalid until the daemon is restarted. Perhaps a 'refresh' signal could be sent over the socket to rebuild this list?

Happy to hear any thoughts on this and make changes as required.
