### PR TITLE
Add systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A daemon wrapper around [Dokku](https://github.com/dokku/dokku)
 
 ## Requirements
 
-A VM running Ubuntu 14.04 x64 with Dokku v0.4.6 installed
+A VM running Ubuntu 14.04 x64 or later with Dokku v0.4.9 installed
 
 ## Installing
 
@@ -40,7 +40,7 @@ A development environment can be started with the provided Vagrantfile. To start
     cd /dokku-daemon
     make test
 
-The executable and Upstart init are symlinked to their respective directories rather than copied.
+The executable and init scripts are symlinked to their respective directories rather than copied. To test using Systemd, start Vagrant with environment variable `BOX_NAME` set to `bento/ubuntu-15.04`.
 
 ## License
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,15 +4,12 @@
 BOX_NAME = ENV["BOX_NAME"] || "bento/ubuntu-14.04"
 BOX_MEMORY = ENV["BOX_MEMORY"] || "512"
 DOKKU_TAG = "v0.4.9"
-DOKKU_DOMAIN = ENV["DOKKU_DOMAIN"] || "dokku.me"
-DOKKU_IP = ENV["DOKKU_IP"] || "10.0.0.2"
 
 Vagrant.configure(2) do |config|
   config.vm.box = BOX_NAME
   config.ssh.forward_agent = true
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     # Ubuntu's Raring 64-bit cloud image is set to a 32-bit Ubuntu OS type by
     # default in Virtualbox and thus will not boot. Manually override that.
     vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
@@ -22,13 +19,10 @@ Vagrant.configure(2) do |config|
   config.vm.define "dokku-daemon", primary: true do |vm|
     vm.vm.synced_folder File.dirname(__FILE__), "/dokku-daemon"
 
-    vm.vm.network :forwarded_port, guest: 80, host: 8080
-    vm.vm.network :private_network, ip: DOKKU_IP
-    vm.vm.hostname = "#{DOKKU_DOMAIN}"
-
     vm.vm.provision :shell, :inline => "apt-get update > /dev/null && apt-get -qq -y install git > /dev/null"
     vm.vm.provision :shell, :inline => "wget https://raw.githubusercontent.com/dokku/dokku/#{DOKKU_TAG}/bootstrap.sh && DOKKU_TAG=#{DOKKU_TAG} bash bootstrap.sh"
     vm.vm.provision :shell, :inline => "cd /dokku-daemon && make ci-dependencies develop"
-    vm.vm.provision :shell, :inline => "initctl reload-configuration"
+    vm.vm.provision :shell, :inline => "[[ `/sbin/init --version 2>&1` =~ upstart ]] && initctl reload-configuration"
+    vm.vm.provision :shell, :inline => "[[ `systemctl 2>&1` =~ -\.mount ]] && systemctl daemon-reload"
   end
 end

--- a/init/dokku-daemon.service
+++ b/init/dokku-daemon.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=dokku-daemon
+
+[Service]
+Environment="DOKKU_LOCK_PATH=/var/lock/dokku-daemon/dokku-daemon.lock"
+Environment="DOKKU_SOCK_PATH=/var/run/dokku-daemon/dokku-daemon.sock"
+Environment="USER=dokku"
+Environment="GROUP=dokku"
+Environment="PERMS=0666"
+EnvironmentFile=-/etc/systemd/system/dokku-daemon.env
+
+ExecStartPre=/bin/bash -c 'DOKKU_LOCK_DIR=$(dirname ${DOKKU_LOCK_PATH}); if [ "$${DOKKU_LOCK_DIR}" != "/tmp" ]; then mkdir -p -m ${PERMS} $${DOKKU_LOCK_DIR}; chown ${USER}:${GROUP} $${DOKKU_LOCK_DIR}; fi'
+ExecStartPre=/bin/bash -c 'DOKKU_SOCK_DIR=$(dirname ${DOKKU_SOCK_PATH}); if [ "$${DOKKU_SOCK_DIR}" != "/tmp" ]; then mkdir -p -m ${PERMS} $${DOKKU_SOCK_DIR}; chown ${USER}:${GROUP} $${DOKKU_SOCK_DIR}; fi'
+
+ExecStart=/usr/bin/dokku-daemon
+ExecStartPost=/bin/sleep 2
+ExecStartPost=/bin/chmod 777 ${DOKKU_SOCK_PATH}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Per #4 this adds a systemd unit file that can be used in place of the Upstart init script for newer versions of Ubuntu.

The Makefile and tests have been updated to use the correct init script based on the installed init system. Using the environment variable `BOX_NAME=bento/ubuntu-15.04` with Vagrant provides a test environment where systemd is installed.
