### PR TITLE
allow *:help commands to go through

### DIFF
--- a/bin/dokku-daemon
+++ b/bin/dokku-daemon
@@ -88,6 +88,7 @@ is_valid_command() {
   local cmd="$(remove_flags "$@" | tr ' ' "\n")"
   local valid=false
   grep -q "^${cmd[0]}$" "$DOKKU_LOCK_PATH" && valid=true
+  [[ "${cmd[0]}" == *help ]] && valid=true
   echo $valid
 }
 

--- a/tests/functional.bats
+++ b/tests/functional.bats
@@ -53,6 +53,26 @@ load test_helper
   daemon_stop
 }
 
+@test "(cmd) *:help dokku commands are allowed through" {
+  daemon_start
+
+  run client_command "apps:help"
+  assert_contains "${lines[*]}" '"ok":true'
+  assert_contains "${lines[*]}" 'apps:create <app>'
+
+  daemon_stop
+}
+
+@test "(cmd) non-existant *:help dokku commands fail" {
+  daemon_start
+
+  run client_command "apps:create:help"
+  assert_contains "${lines[*]}" '"ok":false'
+  assert_contains "${lines[*]}" 'is not a dokku command'
+
+  daemon_stop
+}
+
 @test "(cmd) commands that prompt the user are handled correctly" {
   daemon_start
 


### PR DESCRIPTION
This validates `apps:help` as `true` even though it's not in the cached commands.