### PR TITLE
Add stdin/stdout support. Fixes #3

### DIFF
--- a/bin/dokku-daemon
+++ b/bin/dokku-daemon
@@ -119,8 +119,20 @@ connection() {
             response="Requires --force flag"
             status=1
           else
-            response=$(flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" 2>&1)
-            status="$?"
+            if [[ " ${cmd[-2]} " == *"<"* ]]; then # Check if stdin
+              file_path=${cmd[-1]}
+              unset 'cmd[${#cmd[@]}-1]' # remove last element which is file path
+              unset 'cmd[${#cmd[@]}-1]' # remove last element which is <
+              response=$(flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" < ${file_path} 2>&1)
+            elif [[ " ${cmd[-2]} " == *">"* ]]; then  # Check if stdout
+              file_path=${cmd[-1]}
+              unset 'cmd[${#cmd[@]}-1]' # remove last element which is file path
+              unset 'cmd[${#cmd[@]}-1]' # remove last element which is >
+              response=$(flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" > ${file_path} 2>&1)
+            else
+              response=$(flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" 2>&1)
+              status="$?"
+            fi
           fi
 
           set -e

--- a/bin/dokku-daemon
+++ b/bin/dokku-daemon
@@ -121,13 +121,13 @@ connection() {
           else
             if [[ " ${cmd[-2]} " == *"<"* ]]; then # Check if stdin
               file_path=${cmd[-1]}
-              unset 'cmd[${#cmd[@]}-1]' # remove last element which is file path
-              unset 'cmd[${#cmd[@]}-1]' # remove last element which is <
+              unset "cmd[${#cmd[@]}-1]" # remove last element which is file path
+              unset "cmd[${#cmd[@]}-1]" # remove last element which is <
               response=$(flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" < ${file_path} 2>&1)
             elif [[ " ${cmd[-2]} " == *">"* ]]; then  # Check if stdout
               file_path=${cmd[-1]}
-              unset 'cmd[${#cmd[@]}-1]' # remove last element which is file path
-              unset 'cmd[${#cmd[@]}-1]' # remove last element which is >
+              unset "cmd[${#cmd[@]}-1]" # remove last element which is file path
+              unset "cmd[${#cmd[@]}-1]" # remove last element which is >
               response=$(flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" > ${file_path} 2>&1)
             else
               response=$(flock "$DOKKU_LOCK_PATH" dokku "${cmd[@]}" 2>&1)


### PR DESCRIPTION
This PR adds stdin and stdout support.

It checks the 2nd last element of `cmd` array whether its `<` or `>` and runs the command according to that.

I've tested it with `postgres:import` and `postgres:export` its working except one problem; output of command is empty. How should we handle that?

*Disclaimer: I'm not sure if its a good way, feel free to shoot :)* 