### PR TITLE
Replace double quotes with single quote on command outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ setup-travis:
 	wget -nv -O - https://packagecloud.io/gpg.key | apt-key add -
 	echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main" | tee /etc/apt/sources.list.d/dokku.list
 	apt-get update
-	apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
+	apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
 ifeq ($(DOKKU_VERSION),master)
 	apt-get -y --no-install-recommends install "dokku"
 else

--- a/bin/dokku-daemon
+++ b/bin/dokku-daemon
@@ -30,7 +30,7 @@ json_encode() {
   fi
 
   # Replace newlines with their escaped counterparts
-  local output=$(echo -n "$1" | sed ':a;N;$!ba;s/\n/\\n/g')
+  local output=$(echo -n "$1" | sed ':a;N;$!ba;s/\n/\\n/g' | sed "s/\"/'/g")
 
   printf '{"ok":%s,"output":"%s"}' "$status" "$output"
 }


### PR DESCRIPTION
It fixes the invalid JSON format when the command output includes double quotes(`"`).

My case was;

I sent `config api` to the daemon and my app has a config var with double quotes;

`DOKKU_DOCKERFILE_ENTRYPOINT: ENTRYPOINT ["bundler", "exec"]`

daemon returns;

`{"ok":true,"output":"=====> api config vars\nDATABASE_URL:                postgres://postgres:....@dokku-postgres-api:5432/api\nDOKKU_APP_RESTORE:           1\nDOKKU_APP_TYPE:              dockerfile\nDOKKU_DOCKERFILE_ENTRYPOINT: ENTRYPOINT ["bundler", "exec"]\nDOKKU_NGINX_PORT:            62420\nDOKKU_PROXY_PORT_MAP:        http:62420:5000\nNO_VHOST:                    1\nREDIS_URL:                   redis://api:....@dokku-redis-api:6379"}
`

Which includes unescaped `"` inside the JSON's value field. 

This PR replaces double quotes`"` with single quote `'` from output.